### PR TITLE
Add Git#execute helper method for git commands.

### DIFF
--- a/get_authors.rb
+++ b/get_authors.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/ruby
 # This script gets last 5 authors of a file and writes them at the end of the file.
 
-
 # Git::Log parses output passed from Git#log and creates a hash with author as a key and email as value
 module Git
   class Log
@@ -30,11 +29,22 @@ module Git
     end
   end
 
+  # Take a git command and execute
+  # Abort if command didn't execute successfully
+  # then return output of the command.
+  def self.execute(command)
+    output = `git #{command}`
+
+    abort "Unknown git command: '#{command}'" unless $?.success?
+
+    return output
+  end
+
   # Create instance of Git::Log and pass it output from git log command
   # return 5 last authors of a particular file
   # %an returns author, semicolon for effortless parsing, %ae return email of author
   def self.log(file)
-    Log.new(`git log -5 --pretty=format:"%an;%ae" #{file}`)
+    Log.new(execute("log -5 --pretty=format:'%an;%ae' #{file}"))
   end
 end
 

--- a/test/get_authors_test.rb
+++ b/test/get_authors_test.rb
@@ -17,13 +17,13 @@ class TestGetAuthors < Minitest::Test
     Dir.chdir @dir
 
 
-    `git init`
+    Git.execute 'init'
 
-    `git config user.email "you@example.com"`
-    `git config user.name "Your Name"`
+    Git.execute 'config user.email "you@example.com"'
+    Git.execute 'config user.name "Your Name"'
 
-    `git add .`
-    `git commit -m "Initial commit"`
+    Git.execute 'add .'
+    Git.execute 'commit -m "Initial commit"'
   end
 
   def teardown

--- a/test/git_test.rb
+++ b/test/git_test.rb
@@ -1,0 +1,35 @@
+require "minitest/autorun"
+require "fileutils"
+
+require_relative "../get_authors.rb"
+
+class TestGit < Minitest::Test
+  def setup
+    @original_dir = Dir.pwd
+    @dir = Dir.mktmpdir 'developer-portal'
+
+    @subdir = File.join(@dir, 'subdir')
+
+    Dir.mkdir @subdir
+
+    Dir.chdir @dir
+  end
+
+  def teardown
+    Dir.chdir @original_dir
+    FileUtils.rm_rf @dir
+  end
+
+  def test_that_git_executes_basic_commands
+    assert_match /^git version /, Git.execute('--version')
+  end
+
+  def test_that_git_aborts_on_invalid_command
+    invalid_command = 'patses'
+    err_message = assert_raises(SystemExit) do
+      Git.execute invalid_command
+    end
+
+    assert_equal "Unknown git command: '#{invalid_command}'", "#{err_message}"
+  end
+end


### PR DESCRIPTION
Handle git commands and abort script on git command execution fail.
Substitute calling directly git commands for Git#execute.

Resolves #4.