### PR TITLE
Fix common.sh git command.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -203,7 +203,7 @@ prepgit () {
   vrun "cp -r `getd "website/_site"`/* ."
   vrun "cp -r `getd "website"`/rss.py ."
 
-  vrun "gita -A"
+  vrun "git add -A"
 
   local C="git commit -am"
   echo "${LOGGPR}$C $MSG"


### PR DESCRIPTION
Running `tools/container.sh` would complain about `gita` not being a valid command.

I tried to guess what the command was supposed to be and this seems to work.